### PR TITLE
Modify config.xml MINCToolsPath setting to the correct MINC tool path

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -121,6 +121,6 @@
     </instrumentPermissions>
 
     <!-- MINC TOOLS PATH -->
-    <MINCToolsPath>/opt/minc/</MINCToolsPath>
+    <MINCToolsPath>/opt/minc/1.9.16/</MINCToolsPath>
 
 </config>


### PR DESCRIPTION
This modifies the path to the MINC tools in config.xml to refer to the correct path to the MINC tools on demo.loris.ca